### PR TITLE
Implement update push notification token method

### DIFF
--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -8,7 +8,7 @@ import zendesk.android.Zendesk
 import zendesk.android.ZendeskResult
 import zendesk.android.ZendeskUser
 import zendesk.messaging.android.DefaultMessagingFactory
-
+import zendesk.messaging.android.push.PushNotifications
 
 class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val channel: MethodChannel) {
     companion object {
@@ -85,6 +85,15 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
                 println("$tag - Logout failure : ${error.message}")
                 channel.invokeMethod(logoutFailure, mapOf("error" to error.message))
             }
+        }
+    }
+
+     fun updatePushNotificationToken(token: String) {
+        try {
+            PushNotifications.updatePushNotificationToken(token)
+            println("$tag - updatePushNotificationToken")
+        } catch (error: Throwable) {
+            println("$tag - updatePushNotificationToken failure : ${error.message}")
         }
     }
 }

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -75,6 +75,24 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
                 result.success(zendeskMessaging.getUnreadMessageCount())
             }
+            "updatePushNotificationToken" -> {
+                if (!isInitialized) {
+                    println("$tag - Messaging needs to be initialized first")
+                    return
+                }
+
+                try {
+                    val token = call.argument<String>("token")
+                    if (token == null || token.isEmpty()) {
+                        throw Exception("Token is empty or null")
+                    }
+                    zendeskMessaging.updatePushNotificationToken(token)
+                } catch (err: Throwable) {
+                    println("$tag - Messaging::updatePushNotificationToken invalid arguments. {'token': '<your_token>'} expected !")
+                    println(err.message)
+                    return
+                }
+            }
             else -> {
                 result.notImplemented()
             }

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -5,18 +5,18 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     let TAG = "[SwiftZendeskMessagingPlugin]"
     private var channel: FlutterMethodChannel
     var isInitialized = false
-    
+
     init(channel: FlutterMethodChannel) {
         self.channel = channel
     }
-    
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "zendesk_messaging", binaryMessenger: registrar.messenger())
         let instance = SwiftZendeskMessagingPlugin(channel: channel)
         registrar.addMethodCallDelegate(instance, channel: channel)
         registrar.addApplicationDelegate(instance)
     }
-    
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let method = call.method
         let arguments = call.arguments as? Dictionary<String, Any>
@@ -57,7 +57,14 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 }
                 result(handleMessageCount())
                 break
-            
+            case "updatePushNotificationToken":
+                if (!isInitialized) {
+                    print("\(TAG) - Messaging needs to be initialized first.\n")
+                }
+                let token: String = arguments?["token"] as! String
+                zendeskMessaging.updatePushNotificationToken(token: token)
+                break
+
             case "isInitialized":
                 result(handleInitializedStatus())
                 break

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -76,7 +76,7 @@ public class ZendeskMessaging: NSObject {
     }
 
     func updatePushNotificationToken(token: String) {
-        PushNotifications.updatePushNotificationToken(token)
+        PushNotifications.updatePushNotificationToken(Data(token.utf8))
         print("\(self.TAG) - updatePushNotificationToken\n")
     }
 }

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -9,9 +9,9 @@ public class ZendeskMessaging: NSObject {
     private static var loginFailure: String = "login_failure"
     private static var logoutSuccess: String = "logout_success"
     private static var logoutFailure: String = "logout_failure"
-    
+
     let TAG = "[ZendeskMessaging]"
-    
+
     private var zendeskPlugin: SwiftZendeskMessagingPlugin? = nil
     private var channel: FlutterMethodChannel? = nil
 
@@ -19,7 +19,7 @@ public class ZendeskMessaging: NSObject {
         self.zendeskPlugin = flutterPlugin
         self.channel = channel
     }
-    
+
     func initialize(channelKey: String) {
         print("\(self.TAG) - Channel Key - \(channelKey)\n")
         Zendesk.initialize(withChannelKey: channelKey, messagingFactory: DefaultMessagingFactory()) { result in
@@ -41,7 +41,7 @@ public class ZendeskMessaging: NSObject {
         rootViewController.present(messagingViewController, animated: true, completion: nil)
         print("\(self.TAG) - show")
     }
-    
+
     func loginUser(jwt: String) {
         Zendesk.instance?.loginUser(with: jwt) { result in
             switch result {
@@ -55,7 +55,7 @@ public class ZendeskMessaging: NSObject {
             }
         }
     }
-    
+
     func logoutUser() {
         Zendesk.instance?.logoutUser { result in
             switch result {
@@ -69,8 +69,14 @@ public class ZendeskMessaging: NSObject {
             }
         }
     }
+
     func getUnreadMessageCount() -> Int {
         let count = Zendesk.instance?.messaging?.getUnreadMessageCount()
         return count ?? 0
+    }
+
+    func updatePushNotificationToken(token: String) {
+        PushNotifications.updatePushNotificationToken(token)
+        print("\(self.TAG) - updatePushNotificationToken\n")
     }
 }

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -155,6 +155,14 @@ class ZendeskMessaging {
     }
   }
 
+  static Future<void> updatePushNotificationToken(String token) async {
+    try {
+      await _channel.invokeMethod('updatePushNotificationToken', {'token': token});
+    } catch (e) {
+      debugPrint('ZendeskMessaging - updatePushNotificationToken - Error: $e}');
+    }
+  }
+
   ///  Check if the Zendesk SDK for Android and iOS is already initialized
   static Future<bool> isInitialized() async {
     try {


### PR DESCRIPTION
Implement `updatePushNotificationToken` method to send device token to Zendesk to be able to receive push notifications later.

To test, change dependency to the following:
```
zendesk_messaging:
    git:
      url: https://github.com/LendioDevs/flutter_zendesk_messaging
      ref: update-push-notification-token-method 
```

and run the following commands to clean cache:
```
flutter pub cache clean
flutter pub get
```